### PR TITLE
Update runtime version to 23.08

### DIFF
--- a/com.sevenkfans.sevenkaa.yaml
+++ b/com.sevenkfans.sevenkaa.yaml
@@ -1,6 +1,6 @@
 app-id: com.sevenkfans.sevenkaa
 runtime: org.freedesktop.Platform
-runtime-version: 21.08
+runtime-version: 23.08
 sdk: org.freedesktop.Sdk
 command: 7kaa
 finish-args:


### PR DESCRIPTION
Fix warning 

Info: runtime org.freedesktop.Platform.GL.default branch 21.08 is end-of-life, with reason:
   org.freedesktop.Platform 21.08 is no longer receiving fixes and security updates. Please update to a supported runtime version.

Maybe also fix SSL/TLS cert error while getting music data 